### PR TITLE
Tests refactored for using external json files

### DIFF
--- a/hal/pom.xml
+++ b/hal/pom.xml
@@ -28,6 +28,7 @@
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>1.3</version>
+            <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>uk.co.datumedge</groupId>
@@ -39,6 +40,7 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>18.0</version>
+            <scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/hal/pom.xml
+++ b/hal/pom.xml
@@ -23,5 +23,22 @@
 			<scope>provided</scope>
 			<optional>true</optional>
 		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
+		</dependency>
+		<dependency>
+			<groupId>uk.co.datumedge</groupId>
+			<artifactId>hamcrest-json</artifactId>
+			<version>0.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceDeserializerTest.java
+++ b/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceDeserializerTest.java
@@ -19,20 +19,6 @@
  */
 package com.strategicgains.hyperexpress.serialization.jackson;
 
-<<<<<<< HEAD
-=======
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.List;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-
->>>>>>> upstream/master
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -40,7 +26,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-<<<<<<< HEAD
 import com.strategicgains.hyperexpress.builder.LinkBuilder;
 import com.strategicgains.hyperexpress.domain.Link;
 import com.strategicgains.hyperexpress.domain.Namespace;
@@ -54,20 +39,11 @@ import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
- * @author azytsev
- * @since Feb 2, 2015
-=======
-import com.strategicgains.hyperexpress.domain.Link;
-import com.strategicgains.hyperexpress.domain.hal.HalResource;
-
-/**
- * @author toddf
+ * @author toddf,azaytsev
  * @since Feb 6, 2015
->>>>>>> upstream/master
  */
 public class HalResourceDeserializerTest
 {
@@ -109,50 +85,13 @@ public class HalResourceDeserializerTest
 		assertEquals("/api/orders/9d1b29fc-4240-4993-82c5-a42d00900324/orderstate?orderState=Accepted", links.get(0).getHref());
 		assertEquals("/api/orders/9d1b29fc-4240-4993-82c5-a42d00900324/orderstate?orderState=Declined", links.get(1).getHref());
 	}
-	public void shouldDeserializeEmbeddedArray() throws IOException {
-		HalResource resource = whenReadingFromFile("embedded-array.json");
 
-		assertNotNull(resource);
-		assertEquals(resource.getProperty("name"),"root");
-
-		List<Resource> childrenList = resource.getResources("children");
-		assertNotNull(childrenList);
-		assertEquals(childrenList.size(),2);
-		assertEquals(childrenList.get(0).getProperty("name"),"child 1");
-		assertEquals(childrenList.get(1).getProperty("name"),"child 2");
-	}
 
 	private HalResource whenReadingFromFile(String filename) throws IOException {
 		try(InputStream inputStream = this.getClass().getResourceAsStream(filename)) {
 			return mapper.readValue(inputStream,HalResource.class);
 		}
 	}
-
-//	@Test
-//	public void shouldSerializeResource()
-//	throws JsonProcessingException
-//	{
-//		Resource r = new HalResource().addProperty("name", "root");
-//		r.addNamespace("ns:1", "/namespaces/1");
-//		LinkBuilder l = new LinkBuilder();
-//		r.addLink(l.rel("self").urlPattern("/something").build());
-//		r.addResource("children", new HalResource().addProperty("name", "child"));
-//		String json = mapper.writeValueAsString(r);
-//		thenJsonShouldBeEqualTo(json,"resource.json");
-//	}
-//
-//	@Test
-//	public void shouldSerializeResourceAsArrays()
-//	throws JsonProcessingException
-//	{
-//		Resource r = new HalResource().addProperty("name", "root");
-//		r.addNamespace("ns:1", "/namespaces/1");
-//		LinkBuilder l = new LinkBuilder();
-//		r.addLink(l.rel("self").urlPattern("/something").build(), true);
-//		r.addResource("children", new HalResource().addProperty("name", "child"), true);
-//		String json = mapper.writeValueAsString(r);
-//		thenJsonShouldBeEqualTo(json,"resource-as-arrays.json");
-//	}
 
 	@Test
 	public void shouldDeserializeResourceWithArrays() throws IOException {

--- a/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceDeserializerTest.java
+++ b/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceDeserializerTest.java
@@ -1,0 +1,251 @@
+/*
+    Copyright 2014, Strategic Gains, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+ */
+package com.strategicgains.hyperexpress.serialization.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.strategicgains.hyperexpress.builder.LinkBuilder;
+import com.strategicgains.hyperexpress.domain.Link;
+import com.strategicgains.hyperexpress.domain.Namespace;
+import com.strategicgains.hyperexpress.domain.Resource;
+import com.strategicgains.hyperexpress.domain.hal.HalResource;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author azytsev
+ * @since Feb 2, 2015
+ */
+public class HalResourceDeserializerTest
+{
+	private static ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception
+	{
+		SimpleModule module = new SimpleModule();
+		module.addDeserializer(HalResource.class, new HalResourceDeserializer());
+		mapper.registerModule(module);
+		mapper
+			.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+			.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+			.setSerializationInclusion(JsonInclude.Include.NON_NULL)
+			.setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
+			.setVisibility(PropertyAccessor.GETTER, Visibility.NONE)
+			.setVisibility(PropertyAccessor.SETTER, Visibility.NONE)
+			.setVisibility(PropertyAccessor.IS_GETTER, Visibility.NONE)
+			.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ"));
+	}
+
+//	@Test
+//	public void shouldSerializeSingleNamespace()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		r.addNamespace("ns:1", "/namespaces/1");
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"curies\":{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"}}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeNamespaceArray()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		r.addNamespace("ns:1", "/namespaces/1");
+//		r.addNamespace("ns:2", "/namespaces/2");
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"curies\":[{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"},{\"name\":\"ns:2\",\"href\":\"/namespaces/2\"}]}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeSingleLink()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something").build());
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"self\":{\"href\":\"/something\"}}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeTemplated()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something/{templated}").build());
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"self\":{\"href\":\"/something/{templated}\",\"templated\":true}}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeTemplatedArray()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something/{templated}").build());
+//		r.addLink(l.rel("self").urlPattern("/something/not_templated").build());
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something/{templated}\",\"templated\":true},{\"href\":\"/something/not_templated\"}]}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeLinkArray()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something").build());
+//		r.addLink(l.rel("self").urlPattern("/something/else").build());
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something\"},{\"href\":\"/something/else\"}]}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeAsLinkArray()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something").build(), true);
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something\"}]}}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeProperties()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource();
+//		r.addProperty("name", "A HAL resource");
+//		r.addProperty("value", new Integer(42));
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"name\":\"A HAL resource\",\"value\":42}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeSingleEmbed()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource().addProperty("name", "root");
+//		r.addResource("children", new HalResource().addProperty("name", "child"));
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_embedded\":{\"children\":{\"name\":\"child\"}},\"name\":\"root\"}", json);
+//	}
+//
+//	@Test
+//	public void shouldSerializeEmbedAsArray()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource().addProperty("name", "root");
+//		r.addResource("children", new HalResource().addProperty("name", "child"), true);
+//		String json = mapper.writeValueAsString(r);
+//		assertEquals("{\"_embedded\":{\"children\":[{\"name\":\"child\"}]},\"name\":\"root\"}", json);
+//	}
+
+	@Test
+	public void shouldDeserializeEmbeddedArray() throws IOException {
+		HalResource resource = whenReadingFromFile("embedded-array.json");
+
+		assertNotNull(resource);
+		assertEquals(resource.getProperty("name"),"root");
+
+		List<Resource> childrenList = resource.getResources("children");
+		assertNotNull(childrenList);
+		assertEquals(childrenList.size(),2);
+		assertEquals(childrenList.get(0).getProperty("name"),"child 1");
+		assertEquals(childrenList.get(1).getProperty("name"),"child 2");
+	}
+
+	private HalResource whenReadingFromFile(String filename) throws IOException {
+		try(InputStream inputStream = this.getClass().getResourceAsStream(filename)) {
+			return mapper.readValue(inputStream,HalResource.class);
+		}
+	}
+
+//	@Test
+//	public void shouldSerializeResource()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource().addProperty("name", "root");
+//		r.addNamespace("ns:1", "/namespaces/1");
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something").build());
+//		r.addResource("children", new HalResource().addProperty("name", "child"));
+//		String json = mapper.writeValueAsString(r);
+//		thenJsonShouldBeEqualTo(json,"resource.json");
+//	}
+//
+//	@Test
+//	public void shouldSerializeResourceAsArrays()
+//	throws JsonProcessingException
+//	{
+//		Resource r = new HalResource().addProperty("name", "root");
+//		r.addNamespace("ns:1", "/namespaces/1");
+//		LinkBuilder l = new LinkBuilder();
+//		r.addLink(l.rel("self").urlPattern("/something").build(), true);
+//		r.addResource("children", new HalResource().addProperty("name", "child"), true);
+//		String json = mapper.writeValueAsString(r);
+//		thenJsonShouldBeEqualTo(json,"resource-as-arrays.json");
+//	}
+
+	@Test
+	public void shouldDeserializeResourceWithArrays() throws IOException {
+
+		HalResource halResource = whenReadingFromFile("resource-with-arrays.json");
+
+		assertNotNull(halResource);
+		assertEquals(halResource.getProperty("name"),"root");
+
+		List<Namespace> namespaces = halResource.getNamespaces();
+		assertNotNull(namespaces);
+		assertEquals(namespaces.size(), 2);
+		assertEquals(namespaces.get(0),new Namespace("ns:1", "/namespaces/1"));
+		assertEquals(namespaces.get(1),new Namespace("ns:2", "/namespaces/2"));
+
+		List<Link> links = halResource.getLinks();
+		assertNotNull(links);
+		assertEquals(links.size(),2);
+		LinkBuilder l = new LinkBuilder();
+
+		assertEquals(links.get(0),l.rel("self").urlPattern("/something").build());
+		assertEquals(links.get(1), l.rel("self").urlPattern("/something/{templated}").set("templated", "true").build());
+
+		List<Resource> childrenList = halResource.getResources("children");
+		assertNotNull(childrenList);
+		assertEquals(childrenList.size(),2);
+		assertEquals(childrenList.get(0).getProperty("name"),"child 1");
+		assertEquals(childrenList.get(1).getProperty("name"),"child 2");
+	}
+
+
+}

--- a/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceSerializerTest.java
+++ b/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceSerializerTest.java
@@ -15,13 +15,6 @@
  */
 package com.strategicgains.hyperexpress.serialization.jackson;
 
-import static org.junit.Assert.assertEquals;
-
-import java.text.SimpleDateFormat;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -30,9 +23,20 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.io.CharStreams;
 import com.strategicgains.hyperexpress.builder.LinkBuilder;
 import com.strategicgains.hyperexpress.domain.Resource;
 import com.strategicgains.hyperexpress.domain.hal.HalResource;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.text.SimpleDateFormat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 /**
  * @author toddf
@@ -66,7 +70,7 @@ public class HalResourceSerializerTest
 		Resource r = new HalResource();
 		r.addNamespace("ns:1", "/namespaces/1");
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"curies\":{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"}}}", json);
+		thenJsonShouldBeEqualTo(json, "single-namespace.json");
 	}
 
 	@Test
@@ -77,7 +81,7 @@ public class HalResourceSerializerTest
 		r.addNamespace("ns:1", "/namespaces/1");
 		r.addNamespace("ns:2", "/namespaces/2");
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"curies\":[{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"},{\"name\":\"ns:2\",\"href\":\"/namespaces/2\"}]}}", json);
+		thenJsonShouldBeEqualTo(json, "namespace-array.json");
 	}
 
 	@Test
@@ -88,7 +92,7 @@ public class HalResourceSerializerTest
 		LinkBuilder l = new LinkBuilder();
 		r.addLink(l.rel("self").urlPattern("/something").build());
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"self\":{\"href\":\"/something\"}}}", json);
+		thenJsonShouldBeEqualTo(json, "single-link.json");
 	}
 
 	@Test
@@ -99,7 +103,7 @@ public class HalResourceSerializerTest
 		LinkBuilder l = new LinkBuilder();
 		r.addLink(l.rel("self").urlPattern("/something/{templated}").build());
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"self\":{\"href\":\"/something/{templated}\",\"templated\":true}}}", json);
+		thenJsonShouldBeEqualTo(json, "templated.json");
 	}
 
 	@Test
@@ -111,7 +115,7 @@ public class HalResourceSerializerTest
 		r.addLink(l.rel("self").urlPattern("/something/{templated}").build());
 		r.addLink(l.rel("self").urlPattern("/something/not_templated").build());
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something/{templated}\",\"templated\":true},{\"href\":\"/something/not_templated\"}]}}", json);
+		thenJsonShouldBeEqualTo(json, "templated-array.json");
 	}
 
 	@Test
@@ -176,7 +180,7 @@ public class HalResourceSerializerTest
 		r.addResource("children", new HalResource().addProperty("name", "child 1"));
 		r.addResource("children", new HalResource().addProperty("name", "child 2"));
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_embedded\":{\"children\":[{\"name\":\"child 1\"},{\"name\":\"child 2\"}]},\"name\":\"root\"}", json);
+		thenJsonShouldBeEqualTo(json, "embedded-array.json");
 	}
 
 	@Test
@@ -189,7 +193,7 @@ public class HalResourceSerializerTest
 		r.addLink(l.rel("self").urlPattern("/something").build());
 		r.addResource("children", new HalResource().addProperty("name", "child"));
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"curies\":{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"},\"self\":{\"href\":\"/something\"}},\"_embedded\":{\"children\":{\"name\":\"child\"}},\"name\":\"root\"}", json);
+		thenJsonShouldBeEqualTo(json,"resource.json");
 	}
 
 	@Test
@@ -202,7 +206,7 @@ public class HalResourceSerializerTest
 		r.addLink(l.rel("self").urlPattern("/something").build(), true);
 		r.addResource("children", new HalResource().addProperty("name", "child"), true);
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"curies\":{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"},\"self\":[{\"href\":\"/something\"}]},\"_embedded\":{\"children\":[{\"name\":\"child\"}]},\"name\":\"root\"}", json);
+		thenJsonShouldBeEqualTo(json,"resource-as-arrays.json");
 	}
 
 	@Test
@@ -218,6 +222,20 @@ public class HalResourceSerializerTest
 		r.addResource("children", new HalResource().addProperty("name", "child 1"));
 		r.addResource("children", new HalResource().addProperty("name", "child 2"));
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"curies\":[{\"name\":\"ns:1\",\"href\":\"/namespaces/1\"},{\"name\":\"ns:2\",\"href\":\"/namespaces/2\"}],\"self\":[{\"href\":\"/something\"},{\"href\":\"/something/{templated}\",\"templated\":true}]},\"_embedded\":{\"children\":[{\"name\":\"child 1\"},{\"name\":\"child 2\"}]},\"name\":\"root\"}", json);
+		thenJsonShouldBeEqualTo(json,"resource-with-arrays.json");
+	}
+
+	protected void thenJsonShouldBeEqualTo(String checked,String filePath) {
+		try {
+			assertThat(checked,sameJSONAs(fileContent(filePath)).allowingExtraUnexpectedFields());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public String fileContent(String filename) throws IOException {
+		try(InputStreamReader reader = new InputStreamReader(this.getClass().getResourceAsStream(filename))) {
+			return CharStreams.toString(reader);
+		}
 	}
 }

--- a/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceSerializerTest.java
+++ b/hal/src/test/java/com/strategicgains/hyperexpress/serialization/jackson/HalResourceSerializerTest.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.text.SimpleDateFormat;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
@@ -127,7 +126,7 @@ public class HalResourceSerializerTest
 		r.addLink(l.rel("self").urlPattern("/something").build());
 		r.addLink(l.rel("self").urlPattern("/something/else").build());
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something\"},{\"href\":\"/something/else\"}]}}", json);
+        thenJsonShouldBeEqualTo(json, "link-array2.json");
 	}
 
 	@Test
@@ -138,7 +137,7 @@ public class HalResourceSerializerTest
 		LinkBuilder l = new LinkBuilder();
 		r.addLink(l.rel("self").urlPattern("/something").build(), true);
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_links\":{\"self\":[{\"href\":\"/something\"}]}}", json);
+        thenJsonShouldBeEqualTo(json, "link-array.json");
 	}
 
 	@Test
@@ -149,7 +148,7 @@ public class HalResourceSerializerTest
 		r.addProperty("name", "A HAL resource");
 		r.addProperty("value", new Integer(42));
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"name\":\"A HAL resource\",\"value\":42}", json);
+        thenJsonShouldBeEqualTo(json, "properties.json");
 	}
 
 	@Test
@@ -159,7 +158,7 @@ public class HalResourceSerializerTest
 		Resource r = new HalResource().addProperty("name", "root");
 		r.addResource("children", new HalResource().addProperty("name", "child"));
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_embedded\":{\"children\":{\"name\":\"child\"}},\"name\":\"root\"}", json);
+        thenJsonShouldBeEqualTo(json, "single-embed.json");
 	}
 
 	@Test
@@ -169,7 +168,7 @@ public class HalResourceSerializerTest
 		Resource r = new HalResource().addProperty("name", "root");
 		r.addResource("children", new HalResource().addProperty("name", "child"), true);
 		String json = mapper.writeValueAsString(r);
-		assertEquals("{\"_embedded\":{\"children\":[{\"name\":\"child\"}]},\"name\":\"root\"}", json);
+        thenJsonShouldBeEqualTo(json, "embed-as-array.json");
 	}
 
 	@Test

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/embed-as-array.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/embed-as-array.json
@@ -1,0 +1,4 @@
+{
+  "_embedded": {"children": [{"name": "child"}]},
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/embedded-array.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/embedded-array.json
@@ -1,0 +1,9 @@
+{
+  "_embedded": {
+    "children": [
+      {"name": "child 1"},
+      {"name": "child 2"}
+    ]
+  },
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/link-array.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/link-array.json
@@ -1,0 +1,1 @@
+{"_links": {"self": [{"href": "/something"}]}}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/link-array2.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/link-array2.json
@@ -1,0 +1,8 @@
+{
+  "_links": {
+    "self": [
+      {"href": "/something"},
+      {"href": "/something/else"}
+    ]
+  }
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/namespace-array.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/namespace-array.json
@@ -1,0 +1,14 @@
+{
+  "_links": {
+    "curies": [
+      {
+        "name": "ns:1",
+        "href": "/namespaces/1"
+      },
+      {
+        "name": "ns:2",
+        "href": "/namespaces/2"
+      }
+    ]
+  }
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/properties.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/properties.json
@@ -1,0 +1,1 @@
+{"name":"A HAL resource","value":42}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource-as-arrays.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource-as-arrays.json
@@ -1,0 +1,11 @@
+{
+  "_links": {
+    "curies": {
+      "name": "ns:1",
+      "href": "/namespaces/1"
+    },
+    "self": [{"href": "/something"}]
+  },
+  "_embedded": {"children": [{"name": "child"}]},
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource-with-arrays.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource-with-arrays.json
@@ -1,0 +1,28 @@
+{
+  "_links": {
+    "curies": [
+      {
+        "name": "ns:1",
+        "href": "/namespaces/1"
+      },
+      {
+        "name": "ns:2",
+        "href": "/namespaces/2"
+      }
+    ],
+    "self": [
+      {"href": "/something"},
+      {
+        "href": "/something/{templated}",
+        "templated": true
+      }
+    ]
+  },
+  "_embedded": {
+    "children": [
+      {"name": "child 1"},
+      {"name": "child 2"}
+    ]
+  },
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/resource.json
@@ -1,0 +1,11 @@
+{
+  "_links": {
+    "curies": {
+      "name": "ns:1",
+      "href": "/namespaces/1"
+    },
+    "self": {"href": "/something"}
+  },
+  "_embedded": {"children": {"name": "child"}},
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-embed.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-embed.json
@@ -1,0 +1,4 @@
+{
+  "_embedded": {"children": {"name": "child"}},
+  "name": "root"
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-link.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-link.json
@@ -1,0 +1,6 @@
+{
+  "_links":
+    {
+      "self": {"href": "/something"}
+    }
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-namespace.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/single-namespace.json
@@ -1,0 +1,8 @@
+{
+  "_links": {
+    "curies": {
+      "name": "ns:1",
+      "href": "/namespaces/1"
+    }
+  }
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/templated-array.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/templated-array.json
@@ -1,0 +1,11 @@
+{
+  "_links": {
+    "self": [
+      {
+        "href": "/something/{templated}",
+        "templated": true
+      },
+      {"href": "/something/not_templated"}
+    ]
+  }
+}

--- a/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/templated.json
+++ b/hal/src/test/resources/com/strategicgains/hyperexpress/serialization/jackson/templated.json
@@ -1,0 +1,8 @@
+{
+  "_links": {
+    "self": {
+      "href": "/something/{templated}",
+      "templated": true
+    }
+  }
+}


### PR DESCRIPTION
Hello.

I have added feature for loading\comparing data for serialization\deserialization tests from external files. I see two main advantages of this approach:

1) More readable data. JSON in resource files not cluttered with special characters like in java strings.
2) Reusability. It is possible to reuse one resource file for serialization test and then for deserialization test.

Andrey.  
